### PR TITLE
Relax redis version requirements

### DIFF
--- a/cru-auth-lib.gemspec
+++ b/cru-auth-lib.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'active_model_serializers', '>= 0.10.0.rc1'
-  s.add_dependency 'redis', '~> 3.3'
+  s.add_dependency 'redis', '>= 3.3'
 end

--- a/lib/cru_auth_lib/version.rb
+++ b/lib/cru_auth_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CruAuthLib
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
Redis 4.x is required to use Rails built in redis cache store in Rails 5.2 and above.